### PR TITLE
修复首次点击按钮 canSubmit 为 undefined 问题

### DIFF
--- a/src/directives/validator.js
+++ b/src/directives/validator.js
@@ -30,6 +30,8 @@ function validate(el, modifiers, bindingValue) {
   } else {
     showError(el)
   }
+  
+  checkIsCanSubmit(el)
 }
 
 function showError(el, error) {
@@ -59,6 +61,14 @@ function getErrorElement(el) {
   }
 
   return errorElement
+}
+
+function checkIsCanSubmit(el) {
+  const form = el.closest('[data-validator-form]')
+  const submitBtn = form.querySelector('[type=submit]')
+  const errors = form.querySelectorAll('.has-error')
+
+  submitBtn.canSubmit = !errors.length
 }
 
 export default {


### PR DESCRIPTION
首次点击提交按钮时，canSubmit 为 undefined。
解决方法是在用户输入的时候就检查是否能提交表单。